### PR TITLE
Change base image to ubuntu:18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y python python-pip
 


### PR DESCRIPTION
With ubuntu:16.04, we have got this error on build image when installing pip: 


      
      Step 3/7 : RUN pip install flask
       ---> Running in d1f79649b34d
      Collecting flask
        Downloading https://files.pythonhosted.org/packages/69/b6/53cfa30eed5aa7343daff36622843688ba8c6fe9829bb2b92e193ab1163f/Flask-2.2.2.tar.gz  (677kB)
      Collecting Werkzeug>=2.2.2 (from flask)
        Downloading https://files.pythonhosted.org/packages/f8/c1/1c8e539f040acd80f844c69a5ef8e2fccdf8b442dabb969e497b55d544e1/Werkzeug-2.2.2.tar.gz  (844kB)
        Requested Werkzeug>=2.2.2 from https://files.pythonhosted.org/packages/f8/c1/1c8e539f040acd80f844c69a5ef8e2fccdf8b442dabb969e497b55d544e1/Werkzeug-2.2.2.tar.gz#sha256=7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f  (from flask), but installing version None
      Collecting Jinja2>=3.0 (from flask)
        Downloading https://files.pythonhosted.org/packages/7a/ff/75c28576a1d900e87eb6335b063fab47a8ef3c8b4d88524c4bf78f670cce/Jinja2-3.1.2.tar.gz  (268kB)
        Requested Jinja2>=3.0 from https://files.pythonhosted.org/packages/7a/ff/75c28576a1d900e87eb6335b063fab47a8ef3c8b4d88524c4bf78f670cce/Jinja2-3.1.2.tar.gz#sha256=31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852  (from flask), but installing version None
      Collecting itsdangerous>=2.0 (from flask)
        Downloading https://files.pythonhosted.org/packages/7f/a1/d3fb83e7a61fa0c0d3d08ad0a94ddbeff3731c05212617dff3a94e097f08/itsdangerous-2.1.2.tar.gz  (56kB)
        Requested itsdangerous>=2.0 from https://files.pythonhosted.org/packages/7f/a1/d3fb83e7a61fa0c0d3d08ad0a94ddbeff3731c05212617dff3a94e097f08/itsdangerous-2.1.2.tar.gz#sha256=5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a  (from flask), but installing version None
      Collecting click>=8.0 (from flask)
        Downloading https://files.pythonhosted.org/packages/59/87/84326af34517fca8c58418d148f2403df25303e02736832403587318e9e8/click-8.1.3.tar.gz  (331kB)
        Requested click>=8.0 from https://files.pythonhosted.org/packages/59/87/84326af34517fca8c58418d148f2403df25303e02736832403587318e9e8/click-8.1.3.tar.gz#sha256=7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e  (from flask), but installing version None
      Collecting importlib-metadata>=3.6.0; python_version < "3.10" (from flask)
        Downloading https://files.pythonhosted.org/packages/1a/16/441080c907df829016729e71d8bdd42d99b9bdde48b01492ed08912c0aa9/importlib_metadata-4.12.0.tar.gz  (48kB)
          Complete output from command python setup.py egg_info:
          Traceback (most recent call last):
            File "<string>", line 1, in <module>
          IOError: [Errno 2] No such file or directory: '/tmp/pip-build-E_s6sD/importlib-metadata/setup.py'
          
          ----------------------------------------
      Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-E_s6sD/importlib-metadata/
      You are using pip version 8.1.1, however version 22.2.2 is available.
      You should consider upgrading via the 'pip install --upgrade pip' command.
      Removing intermediate container d1f79649b34d
      error: build error: The command '/bin/sh -c pip install flask' returned a non-zero code: 1

We fix it by changing base image



























